### PR TITLE
Landcovernet pool --> threadpool for jupyter notebook

### DIFF
--- a/notebooks/radiant-mlhub-landcovernet.ipynb
+++ b/notebooks/radiant-mlhub-landcovernet.ipynb
@@ -156,7 +156,7 @@
     "import os\n",
     "from urllib.parse import urlparse\n",
     "import arrow\n",
-    "from multiprocessing import Pool\n",
+    "from multiprocessing.pool import ThreadPool\n",
     "from tqdm import tqdm\n",
     "\n",
     "s3 = boto3.client('s3')\n",
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = Pool(20)\n",
+    "p = ThreadPool(20)\n",
     "to_download = get_items(f'{API_BASE}/collections/{COLLECTION_ID}/items?limit=100',\n",
     "                        max_items_downloaded=10, downloads=[])\n",
     "for d in tqdm(to_download):\n",
@@ -353,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes https://github.com/radiantearth/mlhub-tutorials/issues/35

Changing Pool to ThreadPool in Landcovernet as multiprocessing won't work with jupyter notebook with local functions.