### PR TITLE
Set up binder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ notebooks/.ipynb_checkpoints/
 .DS_Store
 .python-version
 .idea
+notebooks/.ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 RadiantMLHub-intro.docx
 notebooks/.ipynb_checkpoints/
 .DS_Store
+.python-version
+.idea

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Radiant MLHub Tutorials
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/use-binder?filepath=notebooks%2Findex.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/dev?filepath=notebooks%2Findex.ipynb)
 
 This repository contains introductions and Jupyter Notebook examples on how to access Radiant MLHub API.
 
 You can start by reading the [introductory guide](RadiantMLHub-intro.pdf), or jump into using the [Jupyter Notebook examples](./notebooks/index.ipynb) 
 and interact with the API. *You can also run the Jupyter Notebook examples using [binder](https://mybinder.org/) by clicking on the 
-"launch binder" badge above or [this link](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/use-binder?filepath=notebooks%2Findex.ipynb)*. 
+"launch binder" badge above or [this link](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/dev?filepath=notebooks%2Findex.ipynb)*. 
 
 ## Documentation
 You can access the full documentation of Radiant MLHub API [here](http://docs.mlhub.earth). 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Radiant MLHub Tutorials
 
-This repository contains introductions and a Jupyter Notebook example on how to access Radiant MLHub API.
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/use-binder?filepath=notebooks%2Findex.ipynb)
 
-You can start by reading the [introductory guide](RadiantMLHub-intro.pdf), or jump into using the [Jupyter Notebook example](notebooks/) and interact with the API. 
+This repository contains introductions and Jupyter Notebook examples on how to access Radiant MLHub API.
+
+You can start by reading the [introductory guide](RadiantMLHub-intro.pdf), or jump into using the [Jupyter Notebook examples](./notebooks/index.ipynb) 
+and interact with the API. *You can also run the Jupyter Notebook examples using [binder](https://mybinder.org/) by clicking on the 
+"launch binder" badge above or [this link](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/use-binder?filepath=notebooks%2Findex.ipynb)*. 
 
 ## Documentation
 You can access the full documentation of Radiant MLHub API [here](http://docs.mlhub.earth). 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,2 @@
+requests~=2.25.1
+tifffile==2019.7.26.2

--- a/notebooks/RadiantMLHub-intro.ipynb
+++ b/notebooks/RadiantMLHub-intro.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "julian-remainder",
+   "metadata": {},
+   "source": [
+    "[![Radiant MLHub Logo](https://radiant-assets.s3-us-west-2.amazonaws.com/PrimaryRadiantMLHubLogo.png)](https://mlhub.earth/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "future-siemens",
+   "metadata": {},
+   "source": [
+    "# How to access Radiant MLHub data\n",
+    "\n",
+    "The Radiant MLHub API gives access to open Earth observation (EO) training data for machine learning. You can learn more about the repository at the [Radiant MLHub site](https://mlhub.earth) and the organization behind it at the [Radiant Earth Foundation site](https://radiant.earth). \n",
+    "\n",
+    "This is an introductory guide to accessing data. Full documentation for the API is available at https://docs.mlhub.earth. A Jupyter Notebook with sample codes to use the API is also available on Radiant Earth’s [GitHub](https://github.com/radiantearth/mlhub-tutorials). \n",
+    "\n",
+    "You will begin by setting up your authorization, viewing the list of available training data collections and datasets, and retrieving the *items* (the pieces of data contained within them) from those collections. Basic familiarity with Python will be required to access and use the data. \n",
+    "\n",
+    "Radiant MLHub uses [STAC](https://stacspec.org/) standard for cataloging training datasets. Each item in our collection is explained in json format compliant with STAC [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "stone-johns",
+   "metadata": {},
+   "source": [
+    "## Setting up and viewing Collections\n",
+    "\n",
+    "Access to the Radiant MLHub API requires an access token. To get your access token, go to https://dashboard.mlhub.earth. If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. Under **Usage**, you'll see your access token, which you will need. *Do not share* your access token with others: your usage may be limited and sharing your access token is a security risk. \n",
+    "\n",
+    "To see what training data is available, you will need to access the collections available through the API. A collection represents the top-most data level. Typically, this means the data comes from the same source for the same geography. It might include different years or sub-geographies. \n",
+    "\n",
+    "To find data with specific parameters, see the [API documentation](https://docs.mlhub.earth/?python#the-feature-collections-in-the-dataset). Use the collections endpoint to retrieve a list of all collections available and their associated ids."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "studied-audit",
+   "metadata": {},
+   "source": [
+    "## Access items\n",
+    "\n",
+    "Once you have found the collection that you want to access, you can call the item from the API. \n",
+    "\n",
+    "You can then limit what data you get from the item using the optional parameters:\n",
+    "\n",
+    "* **Limit** limits how many items will be returned, with a minimum of 1 and a maximum of 10000.\n",
+    "* **Bounding box** limits the returned items to a specific geographic area.\n",
+    "* **Date time** limits the returned items to those that fall within a specific time-frame. See the [get features](https://docs.mlhub.earth/#getfeatures) API documentation for more information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "buried-colombia",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "italic-prospect",
+   "metadata": {},
+   "source": [
+    "[![Radiant MLHub Logo](https://radiant-assets.s3-us-west-2.amazonaws.com/PrimaryRadiantMLHubLogo.png)](https://mlhub.earth/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "regulated-quick",
+   "metadata": {},
+   "source": [
+    "# Radiant MLHub API Examples\n",
+    "\n",
+    "The notebooks below provide examples and tutorials to cover some common uses of Radiant MLHub data. All examples utilize Python in Jupyter Notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "provincial-disabled",
+   "metadata": {},
+   "source": [
+    "## General\n",
+    "\n",
+    "General examples and tutorials for working with the Radiant MLHub API using Python.\n",
+    "\n",
+    "* [**How to access Radiant MLHub data**](./RadiantMLHub-intro.ipynb): Describes general pattern for accessing data through the Radiant MLHub API, including setting up authentication.\n",
+    "* [**How to use the Radiant MLHub API**](./radiant-mlhub-api-know-how.ipynb): Step-by-step guide for accessing the Radiant MLHub API using Python."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "running-ordinary",
+   "metadata": {},
+   "source": [
+    "## Dataset Tutorials\n",
+    "\n",
+    "Examples and tutorials for accessing specific Radiant MLHub datasets using Python. While this does not cover all datasets available in the API, the principles here can be applied to accessing other datasets.\n",
+    "\n",
+    "* [**How to use the Radiant MLHub API to browse and download the BigEarthNet dataset**](./radiant-mlhub-bigearthnet.ipynb): Step-by-step guide for accessing the BigEarthNet dataset via Radiant MLHub.\n",
+    "* [**How to use the Radiant MLHub API to browse and download the LandCoverNet dataset**](./radiant-mlhub-landcovernet.ipynb): Step-by-step guide for accessing the LandCoverNet dataset via Radiant MLHub."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "criminal-macintosh",
+   "metadata": {},
+   "source": [
+    "## Competition-specific Guides\n",
+    "\n",
+    "Examples and tutorials for working with datasets related to specific competitions/challenges supported by Radiant MLHub. While the datasets may be specific to these competitions, many of the principles may be applicable to other Radiant MLHub datasets as well.\n",
+    "\n",
+    "#### NASA Tropical Storm Wind Speed Challenge\n",
+    "\n",
+    "* [**How to use the Radiant MLHub API to browse and download the NASA Tropical Storm Wind Speed Competition Data**](./NASA%20Tropical%20Storm%20Wind%20Speed%20Challenge/nasa-tropical-storm-wind-speed-challenge-getting-started.ipynb): Basic examples of how to use the API to download labels and source imagery for the NASA Tropical Storm Wind Speed Competition dataset.\n",
+    "* [**Benchmark - Wind-dependent Variables: Predict Wind Speeds of Tropical Storms**](./NASA%20Tropical%20Storm%20Wind%20Speed%20Challenge/nasa-tropical-storm-wind-speed-challenge-benchmark.ipynb): The benchmark solution tutorial for the NASA Tropical Storm Wind Speed Competition.\n",
+    "\n",
+    "#### CV4A ICRL Crop Type Classification Challenge\n",
+    "\n",
+    "* [**A Guide to load the data in Python**](./2020%20CV4A%20Crop%20Type%20Challenge/cv4a-crop-challenge-load-data.ipynb): Examples of loading the CV4A ICRL Crop Type Classification Challenge data using Python.\n",
+    "* [**A Guide to Access the data on Radiant MLHub**](./2020%20CV4A%20Crop%20Type%20Challenge/cv4a-crop-challenge-download-data.ipynb): Examples of accessing and downloading the CV4A ICRL Crop Type Classification Challenge data using Python.\n",
+    "* [**A Guide to load the data in Python (Visualize Bands)**](2020%20CV4A%20Crop%20Type%20Challenge/cv4a-crop-challenge-visualize-s2-data.ipynb): Example of loading the CV4A ICRL Crop Type Classification Challenge data and visualizing bands using Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "outdoor-moses",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Changes

* Configures requirements for `binder` in `binder/` directory
* Adds `binder` badge and link in README
* Adds `notebooks/index.ipynb` to act as landing page 
* Copies content from `RadiantMLHub-intro.pdf` into a Jupyter notebook in `notebooks/RadiantMLHub-intro.ipynb`
    This is so we can include it in the `binder` deployment and so that the links work when viewed as a page in GitHub.

None of the content of the notebooks has been changed. I'll put in a separate PR to update these docs to use the Python client.