### PR TITLE
Bump Python client version

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-radiant-mlhub~=0.1.0
+radiant-mlhub~=0.1.2
 tifffile==2019.7.26.2
 pandas~=1.2.0
 matplotlib~=3.3.4

--- a/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
+++ b/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
@@ -142,20 +142,13 @@
    },
    "outputs": [],
    "source": [
-    "for collection in dataset.collections:\n",
-    "    archive_path = output_path / f'{collection.id}.tar.gz'\n",
-    "    \n",
-    "    if archive_path.exists():\n",
-    "        print(f'Archive {archive_path} exists. Skipping.')\n",
-    "    else:\n",
-    "        print(f'Downloading {archive_path}...')\n",
-    "        collection.download(output_dir=output_path)\n",
-    "        \n",
+    "archive_paths = dataset.download(output_dir=output_path)\n",
+    "for archive_path in archive_paths:\n",
     "    print(f'Extracting {archive_path}...')\n",
     "    with tarfile.open(archive_path) as tfile:\n",
     "        tfile.extractall(path=output_path)\n",
     "\n",
-    "    print('Done\\n')\n"
+    "print('Done\\n')\n"
    ]
   },
   {
@@ -182,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/NASA Tropical Storm Wind Speed Challenge/nasa-tropical-storm-wind-speed-challenge-getting-started.ipynb
+++ b/notebooks/NASA Tropical Storm Wind Speed Challenge/nasa-tropical-storm-wind-speed-challenge-getting-started.ipynb
@@ -182,10 +182,10 @@
    "outputs": [],
    "source": [
     "# Use this to download to a data folder the current working directory\n",
-    "download_dir = Path('./data').resolve()\n",
+    "# download_dir = Path('./data').resolve()\n",
     "\n",
     "# # Use this to download the the typical Mac user Downloads folder\n",
-    "# download_dir = Path('~/Downloads').expanduser().resolve()\n",
+    "download_dir = Path('~/Downloads').expanduser().resolve()\n",
     "\n",
     "# # Use this to download to the typical Linux /tmp directory\n",
     "# download_dir = Path('/tmp')"
@@ -198,17 +198,8 @@
    "outputs": [],
    "source": [
     "# NOTE: Extracting the archives takes a while so this cell may take 5-10 minutes to complete\n",
-    "for collection in dataset.collections:\n",
-    "    # Take just the last part of the collection ID as the key to simplify things.\n",
-    "    #  e.g. nasa_tropical_storm_competition_train_source -> train_source\n",
-    "    archive_path = download_dir / f'{collection.id}.tar.gz'\n",
-    "    \n",
-    "    if archive_path.exists():\n",
-    "        print(f'Archive {archive_path} exists. Skipping.')\n",
-    "    else:\n",
-    "        print(f'Downloading {archive_path}...')\n",
-    "        collection.download(output_dir=download_dir)\n",
-    "    \n",
+    "archive_paths = dataset.download(output_dir=download_dir)\n",
+    "for archive_path in archive_paths:\n",
     "    print(f'Extracting {archive_path}...')\n",
     "    with tarfile.open(archive_path) as tfile:\n",
     "        tfile.extractall(path=download_dir)\n",
@@ -334,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/radiant-mlhub-bigearthnet.ipynb
+++ b/notebooks/radiant-mlhub-bigearthnet.ipynb
@@ -411,13 +411,9 @@
    "outputs": [],
    "source": [
     "output_dir = Path('./data')\n",
-    "archive_path = output_dir / f'{collection_id}.tar.gz'\n",
     "\n",
-    "if archive_path.exists():\n",
-    "    print(f'{archive_path} exists... skipping.')\n",
-    "if not archive_path.exists():\n",
-    "    print(f'Downloading {archive_path}...')\n",
-    "    client.download_archive(collection_id, output_dir=output_dir)"
+    "print(f'Downloading {collection_id} archive...')\n",
+    "client.download_archive(collection_id, output_dir=output_dir)"
    ]
   },
   {


### PR DESCRIPTION
* Bumps `radiant_mlhub` version in Binder requirements to `v0.1.2`
* Updates all `Dataset.download` and `Collection.download` calls to take advantage of skipping existing files
  *This was built into each notebook before, so it simplifies the tutorial code*