### PR TITLE
Google Colab integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,33 @@
 # Radiant MLHub Tutorials
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/master?filepath=notebooks%2Findex.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/radiantearth/mlhub-tutorials/blob/main/notebooks/index.ipynb)
 
 This repository contains introductions and Jupyter Notebook examples on how to access Radiant MLHub API.
 
 You can start by reading the [introductory guide](RadiantMLHub-intro.pdf), or jump into using the [Jupyter Notebook examples](./notebooks/index.ipynb) 
 and interact with the API. 
 
-## Run on Binder
+## Run in Hosted Environment
+
+*Note that the examples involving downloading assets will download those assets to the remote environment and not to 
+your local file system. To download these assets locally you must run the notebooks locally (see next section).*
+
+### Run on Binder
 You can run the Jupyter Notebook examples using [Binder](https://mybinder.org/) by clicking on the 
 "launch binder" badge above or [this link](https://mybinder.org/v2/gh/radiantearth/mlhub-tutorials/master?filepath=notebooks%2Findex.ipynb). 
 The Binder environment will automatically install any dependencies required by the notebooks. 
 
-*Note that the examples involving downloading 
-assets will download those assets to the remote Binder environment and not to your local file system. To download these assets locally you 
-must run the notebooks locally (see next section).* 
+### Run in Google Colab
+You can run the Jupyter Notebook examples using [Google Colab](https://colab.research.google.com/notebooks/intro.ipynb#) 
+by clicking on the "Open in Colab" badge above or [this 
+link](https://colab.research.google.com/github/radiantearth/mlhub-tutorials/blob/main/notebooks/index.ipynb). Colab does 
+not have a mechanism for automatically installing dependencies to a notebook environment like Binder, so *you will need to 
+install all dependencies within the notebook as follows:*
+
+```
+%pip install radiant-mlhub~=0.1.2 tifffile==2019.7.26.2 pandas~=1.2.0 matplotlib~=3.3.4 scikit-image~=0.18.1
+```
 
 ## Run Locally
 


### PR DESCRIPTION
Adds badge and instruction to main README for running tutorial notebooks in Google Colab.

Colab does not have a mechanism for automatically setting up an environment in the same way that Binder does, so users will need to install dependencies themselves. I decided to put instructions for this in the main README rather than adding a cell to each notebook that would have generated a lot of noise for non-Colab users.