### PR TITLE
Updating outdated and broken links throughout the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run the notebooks locally:
     ```
 
 ## Documentation
-You can access the full documentation of Radiant MLHub API [here](http://docs.mlhub.earth). 
+You can access the full documentation of Radiant MLHub API [here](https://mlhub.earth/docs). 
 
 ## Contribute
 If you find these guides useful and would like to contribute, make a pull request or send us an email at ml@radiant.earth.

--- a/RadiantMLHub-intro.md
+++ b/RadiantMLHub-intro.md
@@ -6,16 +6,16 @@ The Radiant MLHub API gives access to open Earth observation (EO) training data 
 
 learning. You can learn more about the repository at the [Radiant MLHub site](https://mlhub.earth/)and the organization behind it at the [Radiant Earth Foundation site.](https://radiant.earth/)
 
-This is an introductory guide to accessing data. Full documentation for the API is available at [docs.mlhub.earth](http://docs.mlhub.earth/)[.](http://docs.mlhub.earth/) A Jupyter Notebook with sample codes to use the API is also available on Radiant Earth’s [GitHub](https://github.com/radiantearth/mlhub-tutorials)
+This is an introductory guide to accessing data. Full documentation for the API is available at [docs.mlhub.earth](https://mlhub.earth/docs)[.](https://mlhub.earth/docs) A Jupyter Notebook with sample codes to use the API is also available on Radiant Earth’s [GitHub](https://github.com/radiantearth/mlhub-tutorials)
 
 You will begin by setting up your authorization, viewing the list of available training data collections and datasets, and retrieving the *items* (the pieces of data contained within them) from those collections. Basic familiarity with Python will be required to access and use the data.
 
 Radiant MLHub uses [STAC](https://stacspec.org/) standard for cataloging training datasets. Each item in our collection is
-explained in json format compliant with STAC [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition.
+explained in json format compliant with STAC [label extension](https://github.com/stac-extensions/label) definition.
 
 ## Setting up and viewing Collections
 
-Access to the Radiant MLHub API requires an access token. To get your access token, go to [dashboard.mlhub.earth](https://dashboard.mlhub.earth/) If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. Under **Usage**, you'll see your access token, which you will need. *Do not share* your access token with others: your usage may be limited and sharing your access token is a security risk.
+Access to the Radiant MLHub API requires an access token. To get your access token, go to [mlhub.earth/profile](https://mlhub.earth/profile) If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. Under **Usage**, you'll see your access token, which you will need. *Do not share* your access token with others: your usage may be limited and sharing your access token is a security risk.
 
 To see what training data is available, you will need to access the collections available through the API. A collection represents the top-most data level. Typically, this means the data comes from the same source for the same geography. It might include different years or sub-geographies.
 

--- a/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
+++ b/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
@@ -161,7 +161,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('venv': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -175,12 +175,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
+   "version": "3.8.6"
    }
-  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
+++ b/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
@@ -176,7 +176,7 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.6"
-   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
+++ b/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
@@ -22,9 +22,9 @@
     "\n",
     "The Radiant MLHub API gives access to open Earth imagery training data for machine learning applications. You can learn more about the repository at the [Radiant MLHub site](https://mlhub.earth) and about the organization behind it at the [Radiant Earth Foundation site](https://radiant.earth).\n",
     "\n",
-    "Full documentation for the API is available at [docs.mlhub.earth](docs.mlhub.earth).\n",
+    "Full documentation for the API is available at [https://mlhub.earth/docs](https://mlhub.earth/docs).\n",
     "\n",
-    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition."
+    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/stac-extensions/label) definition."
    ]
   },
   {
@@ -58,7 +58,7 @@
     "\n",
     "### Create an API Key\n",
     "\n",
-    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [dashboard.mlhub.earth](https://dashboard.mlhub.earth). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
+    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [mlhub.earth/profile](https://mlhub.earth/profile). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
     "\n",
     "### Configure the Client\n",
     "\n",
@@ -161,7 +161,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('venv': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -175,7 +175,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29340fad79fc9aad2df0e1fe597578561d05fda0064e8d6542abf893a0203d17"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
+++ b/notebooks/2020 CV4A Crop Type Challenge/cv4a-crop-challenge-download-data.ipynb
@@ -179,7 +179,6 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "29340fad79fc9aad2df0e1fe597578561d05fda0064e8d6542abf893a0203d17"
    }
   }
  },

--- a/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
+++ b/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
@@ -212,7 +212,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -226,13 +226,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3"
   },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
-  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
+++ b/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
@@ -219,7 +219,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.8.1
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
+++ b/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
@@ -227,7 +227,7 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.1"
-  },
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
+++ b/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
@@ -219,14 +219,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.8.1
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3"
+   "version": "3.8.1"
   },
  },
  "nbformat": 4,

--- a/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
+++ b/notebooks/2022 BRIN Workshop/radiant-mlhub-browse-and-download-a-sample-dataset.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "### Create an API Key\n",
     "\n",
-    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [dashboard.mlhub.earth](https://dashboard.mlhub.earth). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
+    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [mlhub.earth/profile](https://mlhub.earth/profile). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
     "\n",
     "### Configure the Client\n",
     "\n",
@@ -212,7 +212,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -226,7 +226,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/NASA Tropical Storm Wind Speed Challenge/nasa-tropical-storm-wind-speed-challenge-getting-started.ipynb
+++ b/notebooks/NASA Tropical Storm Wind Speed Challenge/nasa-tropical-storm-wind-speed-challenge-getting-started.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "### Create an API Key\n",
     "\n",
-    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [dashboard.mlhub.earth](https://dashboard.mlhub.earth). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
+    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [mlhub.earth/profile](https://mlhub.earth/profile). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
     "\n",
     "### Configure the Client\n",
     "\n",
@@ -311,7 +311,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -325,7 +325,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/NASA Tropical Storm Wind Speed Challenge/nasa-tropical-storm-wind-speed-challenge-getting-started.ipynb
+++ b/notebooks/NASA Tropical Storm Wind Speed Challenge/nasa-tropical-storm-wind-speed-challenge-getting-started.ipynb
@@ -311,7 +311,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -325,12 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/RadiantMLHub-intro.ipynb
+++ b/notebooks/RadiantMLHub-intro.ipynb
@@ -65,7 +65,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -79,12 +79,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/RadiantMLHub-intro.ipynb
+++ b/notebooks/RadiantMLHub-intro.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "## Setting up and viewing Collections\n",
     "\n",
-    "Access to the Radiant MLHub API requires an access token. To get your access token, go to https://dashboard.mlhub.earth. If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. Under **Usage**, you'll see your access token, which you will need. *Do not share* your access token with others: your usage may be limited and sharing your access token is a security risk. \n",
+    "Access to the Radiant MLHub API requires an access token. To get your access token, go to [mlhub.earth/profile](https://mlhub.earth/profile). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. Under **Usage**, you'll see your access token, which you will need. *Do not share* your access token with others: your usage may be limited and sharing your access token is a security risk. \n",
     "\n",
     "To see what training data is available, you will need to access the collections available through the API. A collection represents the top-most data level. Typically, this means the data comes from the same source for the same geography. It might include different years or sub-geographies. \n",
     "\n",
@@ -65,7 +65,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -79,7 +79,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model-S2.ipynb
+++ b/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model-S2.ipynb
@@ -2635,7 +2635,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -2649,12 +2649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model-S2.ipynb
+++ b/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model-S2.ipynb
@@ -22,9 +22,9 @@
     "\n",
     "The Radiant MLHub API gives access to open Earth imagery training data for machine learning applications. You can learn more about the repository at the [Radiant MLHub site](https://mlhub.earth) and about the organization behind it at the [Radiant Earth Foundation site](https://radiant.earth).\n",
     "\n",
-    "Full documentation for the API is available at [docs.mlhub.earth](docs.mlhub.earth).\n",
+    "Full documentation for the API is available at [https://mlhub.earth/docs](https://mlhub.earth/docs).\n",
     "\n",
-    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition."
+    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/stac-extensions/label) definition."
    ]
   },
   {
@@ -42,7 +42,7 @@
    "id": "210d52cd-d81e-446b-8a87-2b0a6cac3bae",
    "metadata": {},
    "source": [
-    "**You must replace the `YOUR_API_KEY_HERE` text with your API key which you can obtain by creating a free account on the [MLHub Dashboard](https://dashboard.mlhub.earth/) within the `API Keys` tab at the top of the page.**"
+    "**You must replace the `YOUR_API_KEY_HERE` text with your API key which you can obtain by creating a free account on the [MLHub Dashboard](https://mlhub.earth/profile/) within the `API Keys` tab at the top of the page.**"
    ]
   },
   {
@@ -2635,7 +2635,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -2649,7 +2649,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model.ipynb
+++ b/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model.ipynb
@@ -22,9 +22,9 @@
     "\n",
     "The Radiant MLHub API gives access to open Earth imagery training data for machine learning applications. You can learn more about the repository at the [Radiant MLHub site](https://mlhub.earth) and about the organization behind it at the [Radiant Earth Foundation site](https://radiant.earth).\n",
     "\n",
-    "Full documentation for the API is available at [docs.mlhub.earth](docs.mlhub.earth).\n",
+    "Full documentation for the API is available at [https://mlhub.earth/docs](https://mlhub.earth/docs).\n",
     "\n",
-    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition."
+    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/stac-extensions/label) definition."
    ]
   },
   {
@@ -1577,7 +1577,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -1591,7 +1591,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model.ipynb
+++ b/notebooks/South Africa Crop Types Competition/Radiant_Earth_Spot_the_Crop_Baseline_Model.ipynb
@@ -1577,7 +1577,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1591,12 +1591,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_asset_paths.ipynb
+++ b/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_asset_paths.ipynb
@@ -22,9 +22,9 @@
     "\n",
     "The Radiant MLHub API gives access to open Earth imagery training data for machine learning applications. You can learn more about the repository at the [Radiant MLHub site](https://mlhub.earth) and about the organization behind it at the [Radiant Earth Foundation site](https://radiant.earth).\n",
     "\n",
-    "Full documentation for the API is available at [docs.mlhub.earth](docs.mlhub.earth).\n",
+    "Full documentation for the API is available at [https://mlhub.earth/docs](https://mlhub.earth/docs).\n",
     "\n",
-    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition."
+    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/stac-extensions/label) definition."
    ]
   },
   {
@@ -62,7 +62,7 @@
     "\n",
     "The cells in this notebook will show you how to download all of the datasets for this competition and read the STAC metadata into a pandas dataframe. There will be two dataframes, one for train and one for test, which contain all of the information you will need to filter based off datetime, satellite platform, and asset type. Contained in each row of the dataframe is also the file path for that asset being described. Assets which have a `None` value for the  `datetime` and `satellite_platform` columns are assets which are related to the label item.\n",
     "\n",
-    "**You must replace the `YOUR_API_KEY_HERE` text with your API key which you can obtain by creating a free account on the [MLHub Dashboard](https://dashboard.mlhub.earth/) within the `API Keys` tab at the top of the page.**"
+    "**You must replace the `YOUR_API_KEY_HERE` text with your API key which you can obtain by creating a free account on the [MLHub Dashboard](https://mlhub.earth/profile/) within the `API Keys` tab at the top of the page.**"
    ]
   },
   {
@@ -673,7 +673,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -687,7 +687,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_asset_paths.ipynb
+++ b/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_asset_paths.ipynb
@@ -673,7 +673,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -687,12 +687,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_selected_bands.ipynb
+++ b/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_selected_bands.ipynb
@@ -635,7 +635,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.3"
-  },
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_selected_bands.ipynb
+++ b/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_selected_bands.ipynb
@@ -620,7 +620,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -634,12 +634,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.8.3"
   },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
   }
  },
  "nbformat": 4,

--- a/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_selected_bands.ipynb
+++ b/notebooks/South Africa Crop Types Competition/south_africa_crop_type_competition_load_selected_bands.ipynb
@@ -22,9 +22,9 @@
     "\n",
     "The Radiant MLHub API gives access to open Earth imagery training data for machine learning applications. You can learn more about the repository at the [Radiant MLHub site](https://mlhub.earth) and about the organization behind it at the [Radiant Earth Foundation site](https://radiant.earth).\n",
     "\n",
-    "Full documentation for the API is available at [docs.mlhub.earth](docs.mlhub.earth).\n",
+    "Full documentation for the API is available at [https://mlhub.earth/docs](https://mlhub.earth/docs).\n",
     "\n",
-    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition."
+    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/stac-extensions/label) definition."
    ]
   },
   {
@@ -620,7 +620,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -634,7 +634,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/radiant-mlhub-api-know-how.ipynb
+++ b/notebooks/radiant-mlhub-api-know-how.ipynb
@@ -329,7 +329,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -343,12 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/radiant-mlhub-api-know-how.ipynb
+++ b/notebooks/radiant-mlhub-api-know-how.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "### Create an API Key\n",
     "\n",
-    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [dashboard.mlhub.earth](https://dashboard.mlhub.earth). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
+    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [https://mlhub.earth/profile](https://mlhub.earth/profile). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
     "\n",
     "### Configure the Client\n",
     "\n",
@@ -329,7 +329,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -343,7 +343,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/radiant-mlhub-bigearthnet.ipynb
+++ b/notebooks/radiant-mlhub-bigearthnet.ipynb
@@ -426,7 +426,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('venv': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -440,12 +440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "29340fad79fc9aad2df0e1fe597578561d05fda0064e8d6542abf893a0203d17"
-   }
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/radiant-mlhub-bigearthnet.ipynb
+++ b/notebooks/radiant-mlhub-bigearthnet.ipynb
@@ -8,11 +8,11 @@
     "\n",
     "# How to use the Radiant MLHub API to browse and download the BigEarthNet dataset\n",
     "\n",
-    "This Jupyter notebook, which you may copy and adapt for any use, shows basic examples of how to use the API to download labels and source imagery for the BigEarthNet dataset. Full documentation for the API is available at [docs.mlhub.earth](docs.mlhub.earth).\n",
+    "This Jupyter notebook, which you may copy and adapt for any use, shows basic examples of how to use the API to download labels and source imagery for the BigEarthNet dataset. Full documentation for the API is available at [mlhub.earth/docs](https://mlhub.earth/docs).\n",
     "\n",
     "We'll show you how to set up your authorization, see the list of available collections and datasets, and retrieve the items (the data contained within them) from those collections. \n",
     "\n",
-    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label) definition."
+    "Each item in our collection is explained in json format compliant with [STAC](https://stacspec.org/) [label extension](https://github.com/stac-extensions/label) definition."
    ]
   },
   {
@@ -21,7 +21,7 @@
    "source": [
     "## Citation Requirements and Contact Information\n",
     "\n",
-    "The BigEarthNet archive was constructed by the Remote Sensing Image Analysis [(RSiM)](https://www.rsim.tu-berlin.de/menue/remote_sensing_image_analysis_group/) Group and the Database Systems and Information Management [(DIMA)](https://www.dima.tu-berlin.de/menue/database_systems_and_information_management_group/?no_cache=1) Group at the Technische Universität Berlin [(TU Berlin)](https://www.tu-berlin.de/menue/home/parameter/en/). This work is supported by the European Research Council under the ERC Starting Grant BigEarth and by the German Ministry for Education and Research as Berlin Big Data Center [(BBDC)](http://www.bbdc.berlin/home/).\n",
+    "The BigEarthNet archive was constructed by the Remote Sensing Image Analysis [(RSiM)](https://www.rsim.tu-berlin.de/menue/remote_sensing_image_analysis_group/) Group and the Database Systems and Information Management [(DIMA)](https://www.dima.tu-berlin.de/menue/database_systems_and_information_management_group/?no_cache=1) Group at the Technische Universität Berlin [(TU Berlin)](https://www.tu-berlin.de/menue/home/parameter/en/). This work is supported by the European Research Council under the ERC Starting Grant BigEarth and by the German Ministry for Education and Research as Berlin Big Data Center [(BBDC)](https://www.zib.de/projects/bbdc-berlin-big-data-center).\n",
     "\n",
     "The BigEarthNet archive *requires* the a citation of the BigEarthNet paper whenever the archive is used. The citation for this paper is listed below along with contact information for inqueries about the archive and a PDF manual detailing the structure of the archive.\n",
     "\n",
@@ -57,7 +57,7 @@
     "\n",
     "### Create an API Key\n",
     "\n",
-    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [dashboard.mlhub.earth](https://dashboard.mlhub.earth). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
+    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [mlhub.earth/profile](https://mlhub.earth/profile). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
     "\n",
     "### Configure the Client\n",
     "\n",
@@ -426,7 +426,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('venv': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -440,7 +440,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "29340fad79fc9aad2df0e1fe597578561d05fda0064e8d6542abf893a0203d17"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/radiant-mlhub-landcovernet.ipynb
+++ b/notebooks/radiant-mlhub-landcovernet.ipynb
@@ -136,7 +136,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -150,12 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
-   }
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/radiant-mlhub-landcovernet.ipynb
+++ b/notebooks/radiant-mlhub-landcovernet.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "### Create an API Key\n",
     "\n",
-    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [dashboard.mlhub.earth](https://dashboard.mlhub.earth). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
+    "Access to the Radiant MLHub API requires an API key. To get your API key, go to [mlhub.earth/profile](https://mlhub.earth/profile). If you have not used Radiant MLHub before, you will need to sign up and create a new account. Otherwise, sign in. In the **API Keys** tab, you'll be able to create API key(s), which you will need. *Do not share* your API key with others: your usage may be limited and sharing your API key is a security risk.\n",
     "\n",
     "### Configure the Client\n",
     "\n",
@@ -136,7 +136,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 ('testing-nb3': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -150,7 +150,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bfc8d50bcab7cd89f4e497954c7bd44c2cd7ea30a283e1a7d953cb82e270bd4c"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. API URL https://docs.mlhub.earth --> https://mlhub.earth/docs 

- `mlhub.earth/docs` links to both the python client docs and the rest api docs.

2. Broken STAC label extention link (https://github.com/radiantearth/stac-spec/tree/master/extensions/label) --> https://github.com/stac-extensions/label

- Updated in all locations 

 
3. https://dashboard.mlhub.earth/ -->  https://mlhub.earth/profile

- `dashboard.mlhub.earth` is an old hostname, which works, but currently is a slow http redirect